### PR TITLE
feat(SOURSD-973): Implement ReadRequest notification for approval or deny of Custodian read access

### DIFF
--- a/src/modules/NotifcationModal/NotificationModal.tsx
+++ b/src/modules/NotifcationModal/NotificationModal.tsx
@@ -60,25 +60,22 @@ export default function NotificationModal({
   const [status, setStatus] = useState<number | null>(null);
   const [requestId, setRequestId] = useState<number | null>(null);
 
-  const { mutateAsync: mutateReadRequest } = usePatchReadRequest(
-    requestId as number,
-    status as number
-  );
+  const { mutateAsync: mutateReadRequest } = usePatchReadRequest();
 
-  const approveOrDenyRequest = (requestId: number, status: number) => {
-    if (!requestId || !status) return;
 
-    mutateReadRequest({
-      requestId,
-      status,
-    })
-      .then(() => {
-        setRequestId(null);
-        setStatus(null);
+  const approveOrDenyRequest = async (requestId: number, status: number) => {
+    if (!requestId || !status ) return;
+
+    try {
+      await mutateReadRequest({
+        requestId,
+        status,
       })
-      .catch(error => {
-        console.error("Error approving/denying request:", error);
-      });
+      setRequestId(null);
+      setStatus(null);
+    } catch (error) {
+      console.error("Error approving/denying request:", error);
+    };
   };
 
   const handleApproveOrDeny = (requestId: number, status: number) => {

--- a/src/modules/NotifcationModal/NotificationModal.tsx
+++ b/src/modules/NotifcationModal/NotificationModal.tsx
@@ -32,7 +32,6 @@ import { formatDBDate } from "@/utils/date";
 import { toTitleCase } from "@/utils/string";
 import { formatNotificationType } from "@/utils/notifications";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
 import usePatchReadRequest from "../NotificationsMenu/hooks/usePatchReadRequest";
 
 const NAMESPACE_TRANSLATIONS = "NotificationsModal";
@@ -57,8 +56,6 @@ export default function NotificationModal({
   const t = useTranslations(NAMESPACE_TRANSLATIONS);
   const theme = useTheme();
   const mobileMediaQuery = theme.breakpoints.down("sm");
-  const [status, setStatus] = useState<number | null>(null);
-  const [requestId, setRequestId] = useState<number | null>(null);
 
   const { mutateAsync: mutateReadRequest } = usePatchReadRequest();
 
@@ -70,17 +67,12 @@ export default function NotificationModal({
         requestId,
         status,
       });
-      setRequestId(null);
-      setStatus(null);
     } catch (error) {
       console.error("Error approving/denying request:", error);
     }
   };
 
   const handleApproveOrDeny = (requestId: number, status: number) => {
-    setRequestId(requestId);
-    setStatus(status);
-
     approveOrDenyRequest(requestId, status);
   };
 
@@ -217,9 +209,13 @@ export default function NotificationModal({
             </TableContainer>
           ) : (
             <>
-              <Box sx={{ mb: 1 }}>
-                {notification.data.details || "No further details."}
-              </Box>
+              <Box
+                sx={{ mb: 1 }}
+                /* This purposefully doesn't use DOMPurify as we explicitly control the content from the API */
+                dangerouslySetInnerHTML={{
+                  __html: notification.data.details || "No further details.",
+                }}
+              />
               <Box
                 sx={{
                   mb: 1,

--- a/src/modules/NotifcationModal/NotificationModal.tsx
+++ b/src/modules/NotifcationModal/NotificationModal.tsx
@@ -62,20 +62,19 @@ export default function NotificationModal({
 
   const { mutateAsync: mutateReadRequest } = usePatchReadRequest();
 
-
   const approveOrDenyRequest = async (requestId: number, status: number) => {
-    if (!requestId || !status ) return;
+    if (!requestId || !status) return;
 
     try {
       await mutateReadRequest({
         requestId,
         status,
-      })
+      });
       setRequestId(null);
       setStatus(null);
     } catch (error) {
       console.error("Error approving/denying request:", error);
-    };
+    }
   };
 
   const handleApproveOrDeny = (requestId: number, status: number) => {

--- a/src/modules/NotifcationModal/NotificationModal.tsx
+++ b/src/modules/NotifcationModal/NotificationModal.tsx
@@ -223,7 +223,7 @@ export default function NotificationModal({
                   justifyContent: "flex-end",
                   gap: 1,
                 }}>
-                {Object.entries(notification.data.buttonUrls).map(
+                {Object.entries(notification.data.buttonUrls ?? {}).map(
                   ([name, id]) => (
                     <Button
                       key={id}

--- a/src/modules/NotificationsMenu/NotificationsMenu.tsx
+++ b/src/modules/NotificationsMenu/NotificationsMenu.tsx
@@ -170,7 +170,7 @@ export default function NotificationsMenu() {
         onClose={handleClose}
         slotProps={{
           paper: {
-            sx: { width: "350px", maxHeight: "300px" },
+            sx: { width: "auto", maxHeight: "300px" },
             onScroll: (event: React.UIEvent<HTMLDivElement>) => {
               event.persist();
               const target = event.currentTarget;

--- a/src/modules/NotificationsMenu/hooks/usePatchReadRequest.tsx
+++ b/src/modules/NotificationsMenu/hooks/usePatchReadRequest.tsx
@@ -1,8 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
 import patchReadRequestNotificationQuery from "@/services/notifications/patchReadRequestNotificationQuery";
 
-
-const usePatchReadRequest = (requestId: number, status: number) =>
-  useMutation(patchReadRequestNotificationQuery(requestId, status, {}));
+const usePatchReadRequest = () => {
+  return useMutation({
+    mutationFn: ({ requestId, status }: {requestId: number, status: number}) => {
+      return patchReadRequestNotificationQuery(requestId, status, {});
+    },
+  });
+};
 
 export default usePatchReadRequest;

--- a/src/modules/NotificationsMenu/hooks/usePatchReadRequest.tsx
+++ b/src/modules/NotificationsMenu/hooks/usePatchReadRequest.tsx
@@ -3,7 +3,13 @@ import patchReadRequestNotificationQuery from "@/services/notifications/patchRea
 
 const usePatchReadRequest = () => {
   return useMutation({
-    mutationFn: ({ requestId, status }: {requestId: number, status: number}) => {
+    mutationFn: ({
+      requestId,
+      status,
+    }: {
+      requestId: number;
+      status: number;
+    }) => {
       return patchReadRequestNotificationQuery(requestId, status, {});
     },
   });

--- a/src/modules/NotificationsMenu/hooks/usePatchReadRequest.tsx
+++ b/src/modules/NotificationsMenu/hooks/usePatchReadRequest.tsx
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query";
+import patchReadRequestNotificationQuery from "@/services/notifications/patchReadRequestNotificationQuery";
+
+
+const usePatchReadRequest = (requestId: number, status: number) =>
+  useMutation(patchReadRequestNotificationQuery(requestId, status, {}));
+
+export default usePatchReadRequest;

--- a/src/services/notifications/patchReadRequestNotificationQuery.ts
+++ b/src/services/notifications/patchReadRequestNotificationQuery.ts
@@ -1,0 +1,15 @@
+import { ResponseOptions } from "@/types/requests";
+import { handleJsonResponse } from "../requestHelpers";
+import { patchRequest } from "../requests";
+
+export default async (
+  requestId: number,
+  status: number,
+  options: ResponseOptions
+) => {
+  const response = await patchRequest(`/request_access/${requestId}`, {
+    status,
+  });
+
+  return handleJsonResponse(response, options);
+};

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -9,6 +9,7 @@ export interface Notification {
     message: string;
     time: string;
     details: Record<string, { old: string; new: string }>;
+    buttonUrls?: Record<string, number>;
     actions?: Action[];
   };
   read_at: string | null;


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/f82f8c55-0218-48d7-a869-1fd43ed8b204)

## Describe your changes
Implements a Read Request notification to be used by Custodian's for a users SOURSD data. Request can be approved/denied. Further BE code is required to block requests if no access has been granted. Todo.

## Issue ticket link
https://hdruk.atlassian.net/browse/SOURSD-973

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as chore, fix, feature, test, refactor
