### PR TITLE
fix(REGISTRY-1473): Prevent crashes from memory issues with the tables

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -64,10 +64,7 @@ const Table = <T,>({
     [perPage.value]
   );
 
-  const safeData = useMemo(
-    () => (Array.isArray(data) ? data.filter(Boolean) : []),
-    [data]
-  );
+  const safeData = useMemo(() => (Array.isArray(data) ? data : []), [data]);
 
   const memoizedColumns = useMemo(() => columns, [columns]);
 
@@ -83,7 +80,7 @@ const Table = <T,>({
   const rows = useMemo(() => {
     const rowModel = table.getRowModel();
     return rowModel?.rows ?? [];
-  }, [table]);
+  }, [safeData]);
 
   return (
     <Results

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -15,7 +15,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useStore } from "@/data/store";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useMemo } from "react";
 import { QueryState } from "../../types/form";
 import Pagination from "../Pagination";
 import Results from "../Results";
@@ -55,19 +55,35 @@ const Table = <T,>({
 }: TableProps<T>) => {
   const perPage = useStore(state => state.getApplication().system.PER_PAGE);
 
-  const table = useReactTable({
-    data: data || [],
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    ...(isPaginated && { getPaginationRowModel: getPaginationRowModel() }),
-    ...restProps,
-    initialState: {
+  const initialState = useMemo(
+    () => ({
       pagination: {
         pageSize: +perPage.value,
       },
-    },
+    }),
+    [perPage.value]
+  );
+
+  const safeData = useMemo(
+    () => (Array.isArray(data) ? data.filter(Boolean) : []),
+    [data]
+  );
+
+  const memoizedColumns = useMemo(() => columns, [columns]);
+
+  const table = useReactTable({
+    data: safeData,
+    columns: memoizedColumns,
+    getCoreRowModel: getCoreRowModel(),
+    ...(isPaginated && { getPaginationRowModel: getPaginationRowModel() }),
+    ...restProps,
+    ...initialState,
   });
+
+  const rows = useMemo(() => {
+    const rowModel = table.getRowModel();
+    return rowModel?.rows ?? [];
+  }, [table]);
 
   return (
     <Results
@@ -119,7 +135,7 @@ const Table = <T,>({
           )}
 
           <TableBody>
-            {table?.getRowModel().rows.map(row => (
+            {rows.map(row => (
               <TableRow key={row.id} role="row">
                 {row.getVisibleCells().map(cell => (
                   <TableCell

--- a/src/modules/ProjectUsersTable/ProjectUsersTable.tsx
+++ b/src/modules/ProjectUsersTable/ProjectUsersTable.tsx
@@ -37,12 +37,13 @@ export default function ProjectUsersTable({
 }: ProjectUsersTableProps) {
   const { createDefaultColumn } = useColumns<CustodianProjectUser>({ t });
 
+  const namePath = useMemo(() => routes?.name?.path, [routes]);
+
   const columns = useMemo(() => {
     const initialColumns: ColumnDef<CustodianProjectUser>[] = [
       createDefaultColumn("name", {
         accessorKey: "project_has_user",
-        cell: info =>
-          renderProjectUserNameCell(info.getValue(), routes?.name?.path),
+        cell: info => renderProjectUserNameCell(info.getValue(), namePath),
       }),
       createDefaultColumn("projectRole", {
         accessorKey: "project_has_user.role.name",
@@ -61,7 +62,7 @@ export default function ProjectUsersTable({
     ];
 
     return filterColumns(initialColumns, includeColumns, extraColumns || []);
-  }, [includeColumns, extraColumns, routes, t]);
+  }, [includeColumns, extraColumns, namePath, createDefaultColumn]);
 
   return <Table columns={columns} isPaginated {...restProps} />;
 }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

When switching between tabs with no data there was a crash, because of too many renders happening 

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-1473?atlOrigin=eyJpIjoiYmNkOGZkMGYwZDY0NDNjMGJlZWE0ZTcxMDU3NGNmMmEiLCJwIjoiaiJ9

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as chore, fix, feature, test, refactor
