### PR TITLE
fix(REGISTRY-1563): Fix to custodian actions

### DIFF
--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1502,9 +1502,9 @@
       "buttonText": "Add Users"
     },
     "addProjectsCompleted": {
-      "title": "Add your projects",
+      "title": "Add your Projects",
       "description": "",
-      "buttonText": "Add projects"
+      "buttonText": "Add Projects"
     },
     "approveAnOrganisationCompleted": {
       "title": "Approve an Organisation",

--- a/src/organisms/ActionLogs/ActionLogs.test.tsx
+++ b/src/organisms/ActionLogs/ActionLogs.test.tsx
@@ -1,0 +1,82 @@
+import { faker } from "@faker-js/faker";
+import { useQuery } from "@tanstack/react-query";
+import { screen, render, userEvent } from "../../utils/testUtils";
+import ActionLogs from "./ActionLogs";
+import { ActionLogEntity } from "../../types/logs";
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(),
+}));
+
+const mockLogs = (count: number, completed = false): ActionLogEntity[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: faker.number.int(),
+    action: `action_test_${i}`,
+    completed_at: completed ? faker.date.recent().toISOString() : null,
+  })) as unknown as ActionLogEntity[];
+
+describe("<ActionLogs />", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders incomplete actions as action items", () => {
+    (useQuery as jest.Mock).mockReturnValue({
+      data: { data: mockLogs(2, false) },
+    });
+
+    render(
+      <ActionLogs
+        variant="organisation"
+        panelProps={{ heading: "Action Logs Test" }}
+      />
+    );
+
+    const heading = screen.getByText("ActionLogs.actionTest_0.title");
+    expect(heading).toBeInTheDocument();
+
+    const button = screen.getByRole("button", {
+      name: "ActionLogs.actionTest_0.buttonText",
+    });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("renders completed actions in accordion", async () => {
+    (useQuery as jest.Mock).mockReturnValue({
+      data: { data: mockLogs(2, true) },
+    });
+
+    render(
+      <ActionLogs
+        variant="organisation"
+        panelProps={{ heading: "Action Log Test" }}
+      />
+    );
+
+    const accordionSummary = screen.getByText("Completed Actions");
+    expect(accordionSummary).toBeInTheDocument();
+
+    let completedItem = screen.getByText("ActionLogs.actionTest_0.title");
+    expect(completedItem).not.toBeVisible();
+
+    await userEvent.click(accordionSummary);
+
+    completedItem = screen.getByText("ActionLogs.actionTest_0.title");
+    expect(completedItem).toBeVisible();
+  });
+
+  it("renders nothing if no actions are returned", () => {
+    (useQuery as jest.Mock).mockReturnValue({
+      data: { data: [] },
+    });
+
+    const { container } = render(
+      <ActionLogs
+        variant="organisation"
+        panelProps={{ heading: "Empty panel" }}
+      />
+    );
+
+    expect(container).not.toHaveTextContent("ActionLogs.actionTest_0.title");
+  });
+});

--- a/src/organisms/ActionLogs/ActionLogs.test.tsx
+++ b/src/organisms/ActionLogs/ActionLogs.test.tsx
@@ -79,4 +79,38 @@ describe("<ActionLogs />", () => {
 
     expect(container).not.toHaveTextContent("ActionLogs.actionTest_0.title");
   });
+
+  it("does not render actions listed in hiddenActions prop", () => {
+    (useQuery as jest.Mock).mockReturnValue({
+      data: {
+        data: [
+          {
+            id: faker.number.int(),
+            action: "add_users_completed", // Should be hidden
+            completed_at: null,
+          },
+          {
+            id: faker.number.int(),
+            action: "visible_action", // Should be shown
+            completed_at: null,
+          },
+        ],
+      },
+    });
+
+    render(
+      <ActionLogs
+        variant="organisation"
+        panelProps={{ heading: "Hidden Actions Test" }}
+        hiddenActions={["add_users_completed"]}
+      />
+    );
+
+    expect(
+      screen.queryByText("ActionLogs.visibleAction.title")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("ActionLogs.addUsersCompleted.title")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/organisms/ActionLogs/ActionLogs.tsx
+++ b/src/organisms/ActionLogs/ActionLogs.tsx
@@ -22,9 +22,14 @@ const NAMESPACE_TRANSLATION_PROFILE = "ActionLogs";
 interface ActionLogProps {
   variant: ActionLogEntity;
   panelProps: Omit<ActionsPanelProps, "children">;
+  hiddenActions?: string[];
 }
 
-export default function ActionLogs({ variant, panelProps }: ActionLogProps) {
+export default function ActionLogs({
+  variant,
+  panelProps,
+  hiddenActions = ["add_users_completed"],
+}: ActionLogProps) {
   const t = useTranslations(NAMESPACE_TRANSLATION_PROFILE);
   const { routes, user } = useStore(state => ({
     routes: state.getApplication().routes,
@@ -47,11 +52,16 @@ export default function ActionLogs({ variant, panelProps }: ActionLogProps) {
     getActionLogsQuery(entityId, variant)
   );
 
+  const allActions =
+    actionLogData?.data.filter(
+      action => !hiddenActions.includes(action.action)
+    ) || [];
+
   const completedActions =
-    actionLogData?.data.filter(action => !!action.completed_at) || [];
+    allActions.filter(action => !!action.completed_at) || [];
 
   const inCompletedActions =
-    actionLogData?.data.filter(action => !action.completed_at) || [];
+    allActions.filter(action => !action.completed_at) || [];
 
   const actions: Record<string, ActionConfig> = generateActions(routes);
 


### PR DESCRIPTION
## Screenshots (if relevant)

![image](https://github.com/user-attachments/assets/b5133ba5-64c4-4ea3-b265-cf71455b2817)


## Describe your changes

Hide user action - this is superseeded by the 'add team members' 

## Issue ticket link

https://hdruk.atlassian.net/browse/REGISTRY-1563

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as chore, fix, feature, test, refactor
