### PR TITLE
fix(REGISTRY-1564): Change Approver and Admin permission to be a radio group

### DIFF
--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/Contacts/Contacts.test.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/Contacts/Contacts.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent, within, waitFor } from "@/utils/testUtils";
 import Contacts from "./Contacts";
 

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/Contacts/Contacts.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/Contacts/Contacts.tsx
@@ -123,18 +123,17 @@ export default function Contacts() {
       <PageBody>
         <PageSection>
           <Box sx={{ display: "flex", gap: 1, mb: 3 }}>
-            <Box component="form" role="search" sx={{ flexGrow: 1 }}>
-              <SearchBar
-                onClear={resetQueryParams}
-                onSearch={(text: string) => {
-                  updateQueryParams({
-                    "name[]": text,
-                    "email[]": text,
-                  });
-                }}
-                placeholder={t("searchPlaceholder")}
-              />
-            </Box>
+            <SearchBar
+              onClear={resetQueryParams}
+              onSearch={(text: string) => {
+                updateQueryParams({
+                  "first_name[]": text,
+                  "last_name[]": text,
+                  "email[]": text,
+                });
+              }}
+              placeholder={t("searchPlaceholder")}
+            />
             <Button
               startIcon={<AddIcon />}
               variant="contained"

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/Contacts/Contacts.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/Contacts/Contacts.tsx
@@ -123,17 +123,23 @@ export default function Contacts() {
       <PageBody>
         <PageSection>
           <Box sx={{ display: "flex", gap: 1, mb: 3 }}>
-            <SearchBar
-              onClear={resetQueryParams}
-              onSearch={(text: string) => {
-                updateQueryParams({
-                  "first_name[]": text,
-                  "last_name[]": text,
-                  "email[]": text,
-                });
-              }}
-              placeholder={t("searchPlaceholder")}
-            />
+            <Box
+              component="form"
+              role="search"
+              sx={{ flexGrow: 1 }}
+              onSubmit={e => e.preventDefault()}>
+              <SearchBar
+                onClear={resetQueryParams}
+                onSearch={(text: string) => {
+                  updateQueryParams({
+                    "first_name[]": text,
+                    "last_name[]": text,
+                    "email[]": text,
+                  });
+                }}
+                placeholder={t("searchPlaceholder")}
+              />
+            </Box>
             <Button
               startIcon={<AddIcon />}
               variant="contained"

--- a/src/app/[locale]/(logged-in)/data-custodian/profile/components/UserModal/UserModal.tsx
+++ b/src/app/[locale]/(logged-in)/data-custodian/profile/components/UserModal/UserModal.tsx
@@ -1,6 +1,5 @@
 import FormModal, { FormModalProps } from "@/components/FormModal";
 import { Message } from "@/components/Message";
-import { CustodianUserRoles } from "@/consts/custodian";
 import { useStore } from "@/data/store";
 import CustodianEditContactForm, {
   CustodianEditContactFormFields,
@@ -72,24 +71,16 @@ export default function UsersModal({
 
   const handleOnSubmit = useCallback(
     async (payload: CustodianEditContactFormFields) => {
-      const { first_name, last_name, email, approver, administrator } = payload;
+      const {
+        first_name,
+        last_name,
+        email,
+        permissions: permissionPayload,
+      } = payload;
 
-      let userPermissions: number[] = [];
-
-      const approverPermission = getPermission(
-        CustodianUserRoles.APPROVER,
-        permissions
-      );
-      const administratorPermissions = getPermission(
-        CustodianUserRoles.ADMINISTRATOR,
-        permissions
-      );
-
-      if (approver && approverPermission) {
-        userPermissions = [approverPermission.id];
-      } else if (administrator && administratorPermissions) {
-        userPermissions = [administratorPermissions.id];
-      }
+      const userPermissions = [
+        getPermission(permissionPayload, permissions)?.id,
+      ];
 
       const userResponse = await mutatePostUser({
         id: user?.id,

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -367,6 +367,7 @@
     "emailAddressAtEmployer": "Email address at employer or institute",
     "firstNameRequiredInvalid": "First name is a required field",
     "lastNameRequiredInvalid": "Last name is a required field",
+    "permissionsRequiredInvalid": "Permissions is a required field",
     "location": "Location",
     "locationRequiredInvalid": "Location is a required field",
     "emailRequiredInvalid": "Email is a required field",

--- a/src/modules/CustodianEditContactForm/CustodianEditContactForm.test.tsx
+++ b/src/modules/CustodianEditContactForm/CustodianEditContactForm.test.tsx
@@ -22,7 +22,22 @@ jest.mock("@/data/store");
 
 const mockOnSubmit = jest.fn();
 const mockOnClose = jest.fn();
-const defaultUser = mockedCustodianUser();
+
+const MOCK_ADMIN_PERMISSION = {
+  custodian_user_id: 1,
+  permission_id: 10,
+  permission: {
+    id: 10,
+    created_at: "2025-07-21T09:12:14.000000Z",
+    updated_at: "2025-07-21T09:12:14.000000Z",
+    name: "CUSTODIAN_ADMIN",
+    enabled: true,
+  },
+};
+
+const defaultUser = mockedCustodianUser({
+  user_permissions: [MOCK_ADMIN_PERMISSION],
+});
 
 const TestComponent = (props?: Partial<CustodianEditContactFormProps>) => {
   const t = useTranslations("CustodianProfile.EditContact");
@@ -52,7 +67,7 @@ describe("<CustodianEditContactForm />", () => {
   it("submit is called", async () => {
     setupTest();
 
-    const { email, first_name, last_name } = defaultUser;
+    const { email, first_name, last_name, user_permissions } = defaultUser;
 
     fireEvent.submit(screen.getByRole("button", { name: /Save/i }));
 
@@ -61,8 +76,7 @@ describe("<CustodianEditContactForm />", () => {
         email,
         first_name,
         last_name,
-        administrator: false,
-        approver: false,
+        permissions: user_permissions[0].permission.name,
       });
     });
   });

--- a/src/modules/SearchField/SearchField.test.tsx
+++ b/src/modules/SearchField/SearchField.test.tsx
@@ -21,11 +21,9 @@ describe("<SearchField />", () => {
   it("submits a search", async () => {
     setupTest();
 
-    act(() => {
-      const searchInput = screen.getByRole("textbox");
+    const searchInput = screen.getByRole("textbox");
 
-      userEvent.type(searchInput, "hdruk{enter}");
-    });
+    await userEvent.type(searchInput, "hdruk{enter}");
 
     await waitFor(() => {
       expect(defaultProps.onSearch).toHaveBeenCalledWith("hdruk");

--- a/src/organisms/CustodianEditContactModal/CustodianEditContactModal.test.tsx
+++ b/src/organisms/CustodianEditContactModal/CustodianEditContactModal.test.tsx
@@ -28,7 +28,21 @@ jest.mock("@/data/store");
 
 const mockOnClose = jest.fn();
 
-const defaultUser = mockedCustodianUser();
+const MOCK_ADMIN_PERMISSION = {
+  custodian_user_id: 1,
+  permission_id: 10,
+  permission: {
+    id: 10,
+    created_at: "2025-07-21T09:12:14.000000Z",
+    updated_at: "2025-07-21T09:12:14.000000Z",
+    name: "CUSTODIAN_ADMIN",
+    enabled: true,
+  },
+};
+
+const defaultUser = mockedCustodianUser({
+  user_permissions: [MOCK_ADMIN_PERMISSION],
+});
 
 const renderCustodianEditContactModalDetails = (
   props?: Partial<CustodianEditContactModalProps>

--- a/src/organisms/CustodianEditContactModal/CustodianEditContactModal.tsx
+++ b/src/organisms/CustodianEditContactModal/CustodianEditContactModal.tsx
@@ -1,6 +1,5 @@
 import FormModal, { FormModalProps } from "@/components/FormModal";
 import { Message } from "@/components/Message";
-import { CustodianUserRoles } from "@/consts/custodian";
 import { useStore } from "@/data/store";
 import CustodianEditContactForm, {
   CustodianEditContactFormFields,
@@ -73,24 +72,16 @@ export default function UsersModal({
 
   const handleOnSubmit = useCallback(
     async (payload: CustodianEditContactFormFields) => {
-      const { first_name, last_name, email, approver, administrator } = payload;
+      const {
+        first_name,
+        last_name,
+        email,
+        permissions: permissionPayload,
+      } = payload;
 
-      let userPermissions: number[] = [];
-
-      const approverPermission = getPermission(
-        CustodianUserRoles.APPROVER,
-        permissions
-      );
-      const administratorPermissions = getPermission(
-        CustodianUserRoles.ADMINISTRATOR,
-        permissions
-      );
-
-      if (approver && approverPermission) {
-        userPermissions = [approverPermission.id];
-      } else if (administrator && administratorPermissions) {
-        userPermissions = [administratorPermissions.id];
-      }
+      const userPermissions = [
+        getPermission(permissionPayload, permissions)?.id,
+      ];
 
       const userResponse = await mutatePostUser({
         id: user?.id,


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="696" height="901" alt="image" src="https://github.com/user-attachments/assets/7a6c2a5f-0845-4fa2-936d-3f2684773cb0" />
<img width="627" height="253" alt="image" src="https://github.com/user-attachments/assets/ee7bbc2e-f370-4b62-8a1a-c8d24a047bad" />

## Describe your changes
- Change Approver and Admin permission to be a radio group
- Make permission field mandatory
- Fix searching by name

**Bugs fixed**
Previously, the search input could be submitted with enter key, reloading the page
Misconfigured translations on the edit modal

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-1564

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
