### PR TITLE
fix(REGISTRY-1573): Status menu selection

### DIFF
--- a/src/components/ActionMenu/ActionMenuItem.tsx
+++ b/src/components/ActionMenu/ActionMenuItem.tsx
@@ -44,8 +44,8 @@ export default function ActionMenuItem({
   }
 
   return (
-    <MenuItem {...restProps} sx={menuItemSx}>
-      <Box sx={{ display: "flex" }}>
+    <MenuItem {...restProps} sx={{ flexDirection: "column", ...menuItemSx }}>
+      <Box sx={{ display: "flex", width: "100%" }}>
         {icon && <ListItemIcon>{icon}</ListItemIcon>}
         <ListItemText
           onClick={() => {

--- a/src/modules/KanbanBoard/KanbanBoardActionMenuItems.tsx
+++ b/src/modules/KanbanBoard/KanbanBoardActionMenuItems.tsx
@@ -19,6 +19,9 @@ export type KanbanBoardActionsMenuItemsProps<T> = WithTranslations<
 export default function KanbanBoardActionsMenuItems<
   T extends {
     id: number;
+    model_state: {
+      state: { slug: string };
+    };
   },
 >({
   t,
@@ -28,7 +31,13 @@ export default function KanbanBoardActionsMenuItems<
   handleClose,
   data,
 }: KanbanBoardActionsMenuItemsProps<T>) {
-  const [status, setStatus] = useState<string>("");
+  const {
+    model_state: {
+      state: { slug },
+    },
+  } = data;
+
+  const [status, setStatus] = useState<string>(slug);
 
   const handleStatusChange = e => {
     setStatus(e.target.value);

--- a/src/modules/KanbanBoard/KanbanBoardActionMenuItems.tsx
+++ b/src/modules/KanbanBoard/KanbanBoardActionMenuItems.tsx
@@ -5,7 +5,7 @@ import {
   ActionMenuItem,
   ActionMenuProps,
 } from "../../components/ActionMenu";
-import { WithTranslations } from "../../types/application";
+import { Translations, WithTranslations } from "../../types/application";
 import { KanbanBoardHelperProps } from "./KanbanBoard";
 
 export type KanbanBoardActionsMenuItemsProps<T> = WithTranslations<
@@ -14,7 +14,7 @@ export type KanbanBoardActionsMenuItemsProps<T> = WithTranslations<
   KanbanBoardHelperProps<unknown> &
   Pick<ActionMenuHelpers, "handleClose"> & {
     data: T;
-  };
+  } & { tStatus: Translations };
 
 export default function KanbanBoardActionsMenuItems<
   T extends {
@@ -22,6 +22,7 @@ export default function KanbanBoardActionsMenuItems<
   },
 >({
   t,
+  tStatus,
   allowedTransitions,
   onMoveClick,
   handleClose,
@@ -42,11 +43,11 @@ export default function KanbanBoardActionsMenuItems<
             gap: 1,
           }}>
           <Select
-            sx={{ minWidth: 200 }}
+            sx={{ minWidth: 200, maxWidth: 200 }}
             value={status}
             onChange={handleStatusChange}>
             {allowedTransitions.map(key => (
-              <MenuItem value={key}>{t(key)}</MenuItem>
+              <MenuItem value={key}>{tStatus(key)}</MenuItem>
             ))}
           </Select>
           <Button variant="outlined" onClick={handleClose}>

--- a/src/organisms/ProjectUsers/ProjectUsers.tsx
+++ b/src/organisms/ProjectUsers/ProjectUsers.tsx
@@ -33,6 +33,7 @@ import ProjectUsersList from "../ProjectUsersList";
 import ProjectUsersActions from "./ProjectUsersActions";
 
 const NAMESPACE_TRANSLATIONS_PROJECT_USERS = "Projects.Users";
+const NAMESPACE_TRANSLATIONS_APPLICATION = "Application.Status";
 
 type ProjectUsersListProps = WithPaginatedQueryParms<
   WithRoutes<{
@@ -50,6 +51,7 @@ export default function ProjectUsers({
   paginatedQueryParams,
 }: ProjectUsersListProps) {
   const t = useTranslations(NAMESPACE_TRANSLATIONS_PROJECT_USERS);
+  const tApplication = useTranslations(NAMESPACE_TRANSLATIONS_APPLICATION);
 
   const [showListView, setShowListView] = useState(
     variant !== EntityType.CUSTODIAN
@@ -151,6 +153,7 @@ export default function ProjectUsers({
             onDelete={() => refetch()}
             onPrimaryContactChange={() => refetch()}
             t={t}
+            tStatus={tApplication}
             onMoveClick={async (id, status) => {
               handleUpdateSafePeople(id, status);
             }}

--- a/src/organisms/ProjectUsers/ProjectUsersActions.tsx
+++ b/src/organisms/ProjectUsers/ProjectUsersActions.tsx
@@ -4,7 +4,11 @@ import KanbanBoardActionsMenuItems from "@/modules/KanbanBoard/KanbanBoardAction
 import useMutateDeleteEntityFromProjectWithConfirmation from "@/queries/useMutateDeleteEntityFromProjectWithConfirmation";
 import { putProjectUserPrimaryContactQuery } from "@/services/projects";
 import { EntityType } from "@/types/api";
-import { CustodianProjectUser, WithTranslations } from "@/types/application";
+import {
+  CustodianProjectUser,
+  Translations,
+  WithTranslations,
+} from "@/types/application";
 import { useMutation } from "@tanstack/react-query";
 
 export type ProjectUsersActionsProps<T = CustodianProjectUser> =
@@ -15,6 +19,7 @@ export type ProjectUsersActionsProps<T = CustodianProjectUser> =
     onPrimaryContactChange: () => void;
     onMoveClick: (id: number, status: string) => void;
     allowedTransitions: string[];
+    tStatus: Translations;
   }>;
 
 export default function ProjectUsersActions({
@@ -23,6 +28,7 @@ export default function ProjectUsersActions({
   onPrimaryContactChange,
   data,
   t,
+  tStatus,
   allowedTransitions,
   ...restProps
 }: ProjectUsersActionsProps) {
@@ -58,6 +64,7 @@ export default function ProjectUsersActions({
             allowedTransitions={allowedTransitions}
             data={data}
             t={t}
+            tStatus={tStatus}
             handleClose={handleClose}
             {...restProps}
           />


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="444" height="209" alt="image" src="https://github.com/user-attachments/assets/90591983-dee6-4b8c-89ad-572be0f6d841" />

## Describe your changes
- Ensure whole width of action menu item is clickable
- Select current status as default value
- Styling fixes for long status names

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-1573

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
