### PR TITLE
fix(REGISTRY-1578): Correct SRO behaviour

### DIFF
--- a/src/app/[locale]/(logged-in)/organisation/profile/components/Delegates/Delegates.tsx
+++ b/src/app/[locale]/(logged-in)/organisation/profile/components/Delegates/Delegates.tsx
@@ -73,6 +73,7 @@ export default function Delegates() {
       email,
       role: job_title,
       department_id: department,
+      is_sro: true,
     };
 
     mutateUser(payload);

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -1361,7 +1361,8 @@
       "technicalSummaryRequiredInvalid": "Technical summary is required",
       "otherApprovalCommittees": "Other approval committees",
       "otherApprovalCommitteesPlaceholder": "Approval committee name"
-    }
+    },
+    "notSet": "None"
   },
   "Error": {
     "login": {

--- a/src/modules/ProjectOrganisationsTable/ProjectOrganisationsTable.tsx
+++ b/src/modules/ProjectOrganisationsTable/ProjectOrganisationsTable.tsx
@@ -51,7 +51,7 @@ export default function ProjectOrganisationsTable({
         accessorKey: "project_organisation.project.title",
       }),
       createDefaultColumn("organisationSroOfficer", {
-        accessorKey: "project_organisation.organisation.sro_officer",
+        accessorKey: "project_organisation.organisation.sro_officer.name",
       }),
       createDefaultColumn("status", {
         accessorKey: "model_state.state.slug",


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="851" height="73" alt="image" src="https://github.com/user-attachments/assets/93a8fda2-ccd5-44e1-b5d4-be90189a8ad6" />

## Describe your changes
Add `is_sro: true` to SRO payload on creation
Display SRO name in table correctly

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-1578

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
