### PR TITLE
fix(REGISTRY-1594): Remove required end date

### DIFF
--- a/src/components/ChipStatus/ChipStatus.tsx
+++ b/src/components/ChipStatus/ChipStatus.tsx
@@ -30,7 +30,28 @@ export enum Status {
   MORE_ORG_INFO_REQ_ESCALATION_MANAGER = "more_org_info_req_escalation_manager",
   MORE_ORG_INFO_REQ_ESCALATION_COMMITTEE = "more_org_info_req_escalation_committee",
   ORG_VALIDATION_DECLINED = "org_validation_declined",
+  USER_LEFT_PROJECT = "user_left_project",
+  ORG_LEFT_PROJECT = "org_left_project_short",
 }
+
+const STATUS_WITH_SHORT_DESCRIPTION = [
+  Status.PENDING,
+  Status.AFFILIATION_PENDING,
+  Status.AFFILIATION_REJECTED,
+  Status.AFFILIATION_LEFT,
+  Status.INVITED,
+  Status.VALIDATION_IN_PROGRESS,
+  Status.MORE_ORG_INFO_REQ,
+  Status.MORE_ORG_INFO_REQ_ESCALATION_COMMITTEE,
+  Status.MORE_ORG_INFO_REQ_ESCALATION_MANAGER,
+  Status.USER_VALIDATION_DECLINED,
+  Status.USER_LEFT_PROJECT,
+  Status.MORE_ORG_INFO_REQ,
+  Status.MORE_ORG_INFO_REQ_ESCALATION_COMMITTEE,
+  Status.MORE_ORG_INFO_REQ_ESCALATION_MANAGER,
+  Status.ORG_VALIDATION_DECLINED,
+  Status.ORG_LEFT_PROJECT,
+];
 
 interface ChipStatusProps extends ChipProps {
   status: Status | undefined;
@@ -85,9 +106,14 @@ export default function ChipStatus({ status, ...restProps }: ChipStatusProps) {
   const color = getColorForStatus(status);
 
   const tooltipKey = `${status}_short`;
-  const shortTranslation = t(tooltipKey);
+
   const hasShortTranslation =
-    shortTranslation !== `${NAMESPACE_TRANSLATION}.${tooltipKey}`;
+    status && STATUS_WITH_SHORT_DESCRIPTION.includes(status);
+
+  let shortTranslation;
+  if (hasShortTranslation) {
+    shortTranslation = t(tooltipKey);
+  }
 
   const label = status
     ? hasShortTranslation

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   DateValidationError,
   LocalizationProvider,
@@ -50,7 +49,7 @@ const DateInput = ({
     <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={locale}>
       <DatePicker
         label={label}
-        value={typeof value === "string" ? new Date(value) : value}
+        value={value && typeof value === "string" ? new Date(value) : null}
         onChange={handleChange}
         format={dateFormat}
         slotProps={{

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -49,7 +49,13 @@ const DateInput = ({
     <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={locale}>
       <DatePicker
         label={label}
-        value={value && typeof value === "string" ? new Date(value) : null}
+        value={
+          value && typeof value === "string"
+            ? new Date(value)
+            : value instanceof Date
+              ? value
+              : null
+        }
         onChange={handleChange}
         format={dateFormat}
         slotProps={{

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -637,7 +637,6 @@
     "startDateRequiredInvalid": "Start date is required",
     "endDate": "End date",
     "endDatePlaceholder": "End date",
-    "endDateRequiredInvalid": "End date is required",
     "webhookEventAriaLabel": "Webhook Event Trigger",
     "webhookRequiredInvalid": "Webhook event trigger is required",
     "duplicateWebhookError": "Duplicate webhooks detected! Your webhook receiver URLs should be unique.",
@@ -683,7 +682,8 @@
       "technicalSummaryPlaceholder": "Technical summary",
       "technicalSummaryRequiredInvalid": "Technical summary is required",
       "otherApprovalCommittees": "Other approval committees",
-      "otherApprovalCommitteesPlaceholder": "Approval committee name"
+      "otherApprovalCommitteesPlaceholder": "Approval committee name",
+      "startDateRequiredInvalid": "Start date is required"
     },
     "SafeData": {
       "arrayRemoveButton": "Remove",

--- a/src/modules/ProjectsSafeProjectForm/ProjectsSafeProjectForm.tsx
+++ b/src/modules/ProjectsSafeProjectForm/ProjectsSafeProjectForm.tsx
@@ -42,7 +42,7 @@ export default function ProjectsSafeProjectForm({
           .string()
           .required(tForm("requestCategoryTypeRequiredInvalid")),
         start_date: yup.string().required(tForm("startDateRequiredInvalid")),
-        end_date: yup.string().required(tForm("endDateRequiredInvalid")),
+        end_date: yup.string().nullable(),
         lay_summary: yup.string().required(tForm("laySummaryRequiredInvalid")),
         public_benefit: yup
           .string()


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="724" height="119" alt="image" src="https://github.com/user-attachments/assets/2bf0a1d7-2e8a-468e-a6da-e934728fd52e" />

## Describe your changes
- Remove Create Project required end date 
- Fix display of date input when no value

## Issue ticket link
https://hdruk.atlassian.net/browse/REGISTRY-1594

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
